### PR TITLE
Arreglado bug que causaba daño doble de enemigos y cortaba animaciones de muerte

### DIFF
--- a/src/enemigos.wlk
+++ b/src/enemigos.wlk
@@ -27,12 +27,10 @@ class Enemigo {
     }
     
     method combate() {
-        combate.entidadAtacando(self)   //Hace saber al combate que él(enemigo/self) será quien empieza
-        combate.iniciarCombate()    //prepara toda el hud del combate y la info necesaria
 
         position = position.left(2)    //se posiciona una celda a la izquierda del personaje
+        combate.iniciarCombate(self)    //prepara el combate, la info necesaria y le hace saber que él(enemigo/self) será quien empieza
 
-        combate.cambiarTurnoA(self) //Empieza el combate
     }
       
     method atacarPre() {

--- a/src/enemigos.wlk
+++ b/src/enemigos.wlk
@@ -60,7 +60,7 @@ class Enemigo {
     }
     
     method recibirDanho(cantidad){
-        salud -= cantidad
+        salud = (salud - cantidad).max(0)
     }
 
     method morir() {

--- a/src/enemigos.wlk
+++ b/src/enemigos.wlk
@@ -26,7 +26,7 @@ class Enemigo {
         self.combate() 
     }
     
-    method combate() {
+    method combate() { //cambio de nombre a iniciarCombate? porque con el sustantivo parece de consulta
 
         position = position.left(2)    //se posiciona una celda a la izquierda del personaje
         combate.iniciarCombate(self)    //prepara el combate, la info necesaria y le hace saber que él(enemigo/self) será quien empieza

--- a/src/pelea.wlk
+++ b/src/pelea.wlk
@@ -16,36 +16,44 @@ object combate {
         self.entidadAtacando(enemigo)
         heroe.enemigoCombatiendo(entidadAtacando)
         hayCombate = true
-        //heroe.estaEnCombate(true)   //en personaje se puede poner combate.hayCombate() en vez de mandarle esto al personaje
         barraEstadoPeleas.enemigo(entidadAtacando)
         barraEstadoPeleas.aparecerJuntoADemasBarras()
-        self.entidadAtaca() //empieza el combate atacando el enemigo
+        self.entidadAtacaOTerminaCombate() //empieza el combate atacando el enemigo
     }
 
     method cambiarTurnoA(entidad){
         entidadAtacando = entidad
-        self.entidadAtaca() //acá se valida si el que ahora tiene el turno sigue con vida y, si es así, este realiza su ataque
+        self.entidadAtacaOTerminaCombate() //acá se valida si el que ahora tiene el turno sigue con vida y, si es así, este realiza su ataque
     }
 
+    /* implementado así, causaba bug donde, dps de matar enemigo, el segundo enemigo al que te enfrentabas golpeaba 2 veces
+    también causaba que las animaciones de muerte de los enemigos se cortaran antes porque tiraba self.error antes de que
+    estas se pudieran ejecutar en su totalidad
     method entidadAtaca() {  
         self.revisarFinDeCombate()      
+        //game.schedule(800, {self.validarCombate()}) //
         self.validarCombate()
+        //game.schedule(805, {entidadAtacando.atacarPre()}) //
         entidadAtacando.atacarPre()
     }
 
     method revisarFinDeCombate() {
         if(entidadAtacando.salud() <= 0) {
             hayCombate = false
-            //heroe.estaEnCombate(false)
             barraEstadoPeleas.desaparecerJuntoADemasBarras()
-            entidadAtacando.morir()
+            entidadAtacando.morir() //ACÁ PARECE ESTAR EL ERROR. 
         }
     }
+    */
 
-    method validarCombate() {
-        if(!hayCombate){
-            self.error("")
-        }
+    method entidadAtacaOTerminaCombate() {  
+        if(entidadAtacando.salud() <= 0) {
+            hayCombate = false
+            entidadAtacando.morir()
+            game.schedule(805, {barraEstadoPeleas.desaparecerJuntoADemasBarras()}) //con schedule para que se puedan ver animaciones d muerte
+        } else {
+            entidadAtacando.atacarPre()
+        }   
     }
 
 }

--- a/src/pelea.wlk
+++ b/src/pelea.wlk
@@ -10,13 +10,13 @@ object combate {
 
     var property entidadAtacando = null //aquel que tiene el turno para atacar
     const heroe = personaje
-    var hayCombate = false
+    var property hayCombate = false
 
     method iniciarCombate(enemigo){
         self.entidadAtacando(enemigo)
         heroe.enemigoCombatiendo(entidadAtacando)
         hayCombate = true
-        heroe.estaEnCombate(true)   //en personaje se puede poner combate.hayCombate() en vez de mandarle esto al personaje
+        //heroe.estaEnCombate(true)   //en personaje se puede poner combate.hayCombate() en vez de mandarle esto al personaje
         barraEstadoPeleas.enemigo(entidadAtacando)
         barraEstadoPeleas.aparecerJuntoADemasBarras()
         self.entidadAtaca() //empieza el combate atacando el enemigo
@@ -36,7 +36,7 @@ object combate {
     method revisarFinDeCombate() {
         if(entidadAtacando.salud() <= 0) {
             hayCombate = false
-            heroe.estaEnCombate(false)
+            //heroe.estaEnCombate(false)
             barraEstadoPeleas.desaparecerJuntoADemasBarras()
             entidadAtacando.morir()
         }
@@ -46,9 +46,6 @@ object combate {
         if(!hayCombate){
             self.error("")
         }
-    }
-    method hayCombate(cond){
-        hayCombate = cond
     }
 
 }

--- a/src/pelea.wlk
+++ b/src/pelea.wlk
@@ -12,12 +12,14 @@ object combate {
     const heroe = personaje
     var hayCombate = false
 
-    method iniciarCombate(){
+    method iniciarCombate(enemigo){
+        self.entidadAtacando(enemigo)
         heroe.enemigoCombatiendo(entidadAtacando)
         hayCombate = true
         heroe.estaEnCombate(true)   //en personaje se puede poner combate.hayCombate() en vez de mandarle esto al personaje
         barraEstadoPeleas.enemigo(entidadAtacando)
         barraEstadoPeleas.aparecerJuntoADemasBarras()
+        self.entidadAtaca() //empieza el combate atacando el enemigo
     }
 
     method cambiarTurnoA(entidad){

--- a/src/personaje.wlk
+++ b/src/personaje.wlk
@@ -85,7 +85,7 @@ object personaje {
 
 	method validarMoverPelea() {
 		if (self.estaEnCombate()) {
-			self.error(null)
+			self.error("")
 		}
 	}
 
@@ -127,7 +127,7 @@ object personaje {
 	}
 
 	method recibirDanho(cantidad) {
-		salud -= cantidad
+		salud = (salud - cantidad).max(0)
 	}
 
 	method actualizarArmaActual() { //esto se ejecuta solamente cuando se descarta el arma actual

--- a/src/personaje.wlk
+++ b/src/personaje.wlk
@@ -17,7 +17,6 @@ object personaje {
 	const cantArmasPermitidas = 3
 	const cantPocionesPermitidas = 3
 	const property bolsa = []
-	var estaEnCombate = false
 	var property armaActual = mano //porque empieza con bolsa vacía
 
 	method position() {
@@ -85,7 +84,7 @@ object personaje {
 	}
 
 	method validarMoverPelea() {
-		if (estaEnCombate) {
+		if (self.estaEnCombate()) {
 			self.error(null)
 		}
 	}
@@ -94,8 +93,8 @@ object personaje {
     var property enemigoCombatiendo = null //el enemigo con quien está en combate
 	var esTurno = false //si es su turno en un combate
 
-    method estaEnCombate(condicion){
-        estaEnCombate = condicion
+    method estaEnCombate(){
+        return combate.hayCombate()
     }
 
     method atacarPre() {
@@ -115,7 +114,7 @@ object personaje {
 	}
 
 	method validarHacerTurno() {
-        if(!estaEnCombate || !esTurno || animacion!=animacionEstatica){
+        if(!self.estaEnCombate() || !esTurno || animacion!=animacionEstatica){
             self.error("No puedo ejecutar una habilidad ahora")
         }
     }


### PR DESCRIPTION
-Se arregla bug donde, después de matar enemigo, el segundo enemigo al que te enfrentabas golpeaba 2 veces. 
-También causaba que las animaciones de muerte de los enemigos se cortaran antes porque tiraba un self.error antes de que estas se pudieran ejecutar en su totalidad.
-Antes había método que se fijaba si la vida del atacante era menor o igual a 0.  Si así era, terminaba combate (cambiaba estado) y tiraba excepción. Si no se daba ese caso, atacaba.
Es mejor solución implementar un método condicional que hace ataque o, si no corresponde, termina combate (cambio de estado) en vez de tirar una excepción, ya que la excepción tiene más sentido en el caso de que, si el atacante no puede atacar, no quiero que se haga nada (NO cambio de estado).
Acá, en cambio, cuando no se puede atacar por falta de vida del atacante, lo que queremos es que SÍ pase algo (que se borre al enemigo y la info del combate).